### PR TITLE
Fixes #59, small additional support in image detection & relative path rewrites

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,6 @@ require('yargs/yargs')(process.argv.slice(2))
       alias: 'e',
       describe: 'API endpoint for QuantCDN',
       type: 'string',
-      default: 'https://api.quantcdn.io',
     })
     .demandCommand()
     .wrap(100)

--- a/src/commands/crawl.js
+++ b/src/commands/crawl.js
@@ -26,7 +26,6 @@ let count = 0;
 let writingState = false;
 let filename;
 
-const tmpfiles = [];
 const failures = [];
 const get = util.promisify(request.get);
 
@@ -157,8 +156,6 @@ command.handler = async function(argv) {
     console.log(chalk.bold.green('✅ All done! ') + ` ${count} total items.`);
     console.log(chalk.bold.green('Failed items:'));
     console.log(failures);
-    console.log(`Removing temporary files ${tempfiles.length}`);
-    tmpfiles.map(fs.unlinkSync);
     write(crawl, filename);
   });
 
@@ -220,8 +217,6 @@ command.handler = async function(argv) {
       const opts = {url: queueItem.url, encoding: null};
       const response = await get(opts);
 
-      tmpfiles.push(tmpfile.name);
-
       if (!response.body || response.body.byteLength < 50) {
         queueItem.status = 'failed';
         file.close();
@@ -242,6 +237,9 @@ command.handler = async function(argv) {
       try {
         await quant.file(tmpfile.name, url, true, extraHeaders);
       } catch (err) {}
+
+      // Remove temporary file immediately.
+      fs.unlinkSync(tmpfile.name);
     }
     count++;
   });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -49,8 +49,8 @@ command.handler = function(argv) {
           default: 'https://api.quantcdn.io',
         },
         clientid: {
-          pattern: /^[a-zA-Z0-9\-]+$/,
-          message: 'Client id must be only letters, numbers or dashes',
+          pattern: /^[a-zA-Z0-9\-\_]+$/,
+          message: 'Client id must be only letters, numbers, underscores or dashes',
           required: true,
           description: 'Enter QuantCDN client id',
         },

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ const filename = 'quant.json';
 
 const config = {
   dir: 'build',
-  endpoint: 'http://quantcdn.io',
+  endpoint: 'https://api.quantcdn.io',
   clientid: null,
   project: null,
   token: null,

--- a/src/crawl/detectors/images.js
+++ b/src/crawl/detectors/images.js
@@ -6,6 +6,7 @@ const {decode} = require('html-entities');
 const matchAll = require('string.prototype.matchall');
 const bgImg = /background(-image)?:.*?url\(\s*(?<url>.*?)\s*\)/gi;
 const dataSrc = /data-src(?:\-retina)?=\"(?<url>[^']*?)\"/gi;
+const xlinkHref = /xlink:href=\"(?<url>.*?)\"/gi;
 
 module.exports = {
   applies: (response) => {
@@ -16,7 +17,7 @@ module.exports = {
       string = string.toString();
     }
 
-    const items = [...matchAll(string, bgImg), ...matchAll(string, dataSrc)];
+    const items = [...matchAll(string, bgImg), ...matchAll(string, dataSrc), ...matchAll(string, xlinkHref)];
 
     if (items.length < 0) {
       return [];

--- a/src/crawl/filters/relativeDomains.js
+++ b/src/crawl/filters/relativeDomains.js
@@ -12,7 +12,7 @@
 module.exports = {
   option: 'rewrite',
   handler: (dom, opts) => {
-    const regex = new RegExp(`http[s]?:\/\/${opts.host}(:\\d+)?`, 'gi');
-    return dom.replace(regex, '');
+    const regex = new RegExp(`http[s]?:\/\/${opts.host}(:\\d+)?\/[\/]?`, 'gi');
+    return dom.replace(regex, '/');
   },
 };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 describe('Config', function() {
   describe('defaults', function() {
     it('should have a default endpoint', function() {
-      assert.equal(config.get('endpoint'), 'http://quantcdn.io/v1');
+      assert.equal(config.get('endpoint'), 'https://api.quantcdn.io/v1');
     });
     it('should have a default directory', function() {
       assert.equal(config.get('dir'), 'build');


### PR DESCRIPTION
Fixes #59.

- Support additional image detection.
- Fix bad absolute references with double-slash in path (e.g `https://www.domain.com//path/to/content`)