### PR TITLE
Disable unpublish with a flag.

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -29,6 +29,12 @@ command.builder = (yargs) => {
     type: 'boolean',
     default: false,
   });
+  yargs.options('disable-unpublish', {
+    describe: 'Disable the automatic cleanup process',
+    alias: 'u',
+    type: 'boolean',
+    default: false,
+  });
 };
 
 command.handler = async function(argv) {
@@ -87,6 +93,11 @@ command.handler = async function(argv) {
     }
     console.log(chalk.bold.green('✅') + ` ${filepath}`);
   });
+
+  if (argv['disable-unpublish']) {
+    console.log(chalk.yellow('[skip]: Skipping automatic path removal.'));
+    return;
+  }
 
   try {
     data = await quant.meta(true);

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -29,7 +29,7 @@ command.builder = (yargs) => {
     type: 'boolean',
     default: false,
   });
-  yargs.options('disable-unpublish', {
+  yargs.options('skip-unpublish', {
     describe: 'Skip the automatic unpublish process',
     alias: 'u',
     type: 'boolean',

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -30,7 +30,7 @@ command.builder = (yargs) => {
     default: false,
   });
   yargs.options('disable-unpublish', {
-    describe: 'Disable the automatic cleanup process',
+    describe: 'Skip the automatic unpublish process',
     alias: 'u',
     type: 'boolean',
     default: false,

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -95,7 +95,7 @@ command.handler = async function(argv) {
   });
 
   if (argv['disable-unpublish']) {
-    console.log(chalk.yellow('[skip]: Skipping automatic path removal.'));
+    console.log(chalk.yellow('[skip]: Skipping automatic unpublish'));
     return;
   }
 


### PR DESCRIPTION
- Adds a flag to `deploy` to disable the automatic unpublish of routes