### PR TITLE
Allow manual URL list to be passed to crawler

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --max-old-space-size=14000
+#!/usr/bin/env node --max-old-space-size=4096
 
 require('yargs/yargs')(process.argv.slice(2))
     .strict()

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max-old-space-size=14000
 
 require('yargs/yargs')(process.argv.slice(2))
     .strict()

--- a/src/commands/crawl.js
+++ b/src/commands/crawl.js
@@ -86,6 +86,10 @@ command.builder = {
     type: 'boolean',
     default: false,
   },
+  'urls-file': {
+    describe: 'JSON file containing array of URLs to add to the queue',
+    type: 'string'
+  }
 };
 
 /**
@@ -121,8 +125,18 @@ command.handler = async function(argv) {
     return;
   }
 
-  crawl = crawler(domain);
+  // Queue URLs from urls-file if provided.
+  urlsdata = [];
+  if (argv['urls-file'] && argv['urls-file'].length > 0) {
+    try {
+      urlsdata = JSON.parse(fs.readFileSync(argv['urls-file']));
+    } catch (error) {
+      console.log(chalk.bold.red('❌ ERROR: Cannot read urls-file: ' + argv['urls-file']));
+      process.exit(1)
+    }
+  }
 
+  crawl = crawler(domain);
   crawl.interval = argv.interval;
   crawl.decodeResponses = true;
   crawl.maxResourceSize = argv.size; // 256MB
@@ -242,6 +256,8 @@ command.handler = async function(argv) {
       try {
         await quant.file(tmpfile.name, url, true, extraHeaders);
       } catch (err) {}
+
+      fs.unlinkSync(tmpfile.name)
     }
     count++;
   });
@@ -249,7 +265,10 @@ command.handler = async function(argv) {
   if (!argv['skip-resume']) {
     let result;
 
-    if (!argv['no-interaction']) {
+    if (!fs.existsSync(`${os.homedir()}/.quant/${filename}`)) {
+      result = {resume: false};
+    }
+    else if (!argv['no-interaction']) {
       prompt.start();
       result = await prompt.get({
         properties: {
@@ -266,17 +285,31 @@ command.handler = async function(argv) {
     }
 
     if (result.resume) {
+
+      // Prevent manual URL list when resuming.
+      if (urlsdata.length > 0) {
+        console.log(chalk.bold.green('❌ ERROR: Cannot use --urls-file while resuming, ignoring.'));
+        urlsdata = [];
+      }
+
       // Defrost is async and supports non-existent files.
       crawl.queue.defrost(`${os.homedir()}/.quant/${filename}`, (err) => {
         console.log(chalk.bold.green('✅ DONE: Loaded resume state from ' + `${os.homedir()}/.quant/${filename}`)); // eslint-disable-line max-len
-        crawl.start();
       });
-    } else {
-      crawl.start();
     }
+
   } else {
-    crawl.start();
+    console.log(chalk.bold.green('Skipping resume state via --skip-resume.'));
   }
+
+  // Inject URLs provided via urls-file.
+  if (urlsdata.length > 0) {
+    for (const url of urlsdata) {
+      crawl.queueURL(url);
+    }
+  }
+
+  crawl.start();
 };
 
 module.exports = command;

--- a/src/commands/crawl.js
+++ b/src/commands/crawl.js
@@ -87,8 +87,8 @@ command.builder = {
   },
   'urls-file': {
     describe: 'JSON file containing array of URLs to add to the queue',
-    type: 'string'
-  }
+    type: 'string',
+  },
 };
 
 /**
@@ -131,7 +131,7 @@ command.handler = async function(argv) {
       urlsdata = JSON.parse(fs.readFileSync(argv['urls-file']));
     } catch (error) {
       console.log(chalk.bold.red('❌ ERROR: Cannot read urls-file: ' + argv['urls-file']));
-      process.exit(1)
+      process.exit(1);
     }
   }
 
@@ -263,8 +263,7 @@ command.handler = async function(argv) {
 
     if (!fs.existsSync(`${os.homedir()}/.quant/${filename}`)) {
       result = {resume: false};
-    }
-    else if (!argv['no-interaction']) {
+    } else if (!argv['no-interaction']) {
       prompt.start();
       result = await prompt.get({
         properties: {
@@ -281,7 +280,6 @@ command.handler = async function(argv) {
     }
 
     if (result.resume) {
-
       // Prevent manual URL list when resuming.
       if (urlsdata.length > 0) {
         console.log(chalk.bold.green('❌ ERROR: Cannot use --urls-file while resuming, ignoring.'));
@@ -293,7 +291,6 @@ command.handler = async function(argv) {
         console.log(chalk.bold.green('✅ DONE: Loaded resume state from ' + `${os.homedir()}/.quant/${filename}`)); // eslint-disable-line max-len
       });
     }
-
   } else {
     console.log(chalk.bold.green('Skipping resume state via --skip-resume.'));
   }


### PR DESCRIPTION
This adds an option to the crawler to parse a file containing a list of URLs to add to the queue.

Usage: `quant crawl --urls-file=/path/to/file.json`

Where `file.json` is a simple array of absolute URLs:
```
[
  "https://www.google.com/url-a",
  "https://www.google.com/url-b"
  ...
]
```

This is useful for allowing orphaned URLs to be added to ongoing crawl operations.