### PR TITLE
Add type to meta response.

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -178,11 +178,18 @@ command.handler = async function(argv) {
     return;
   }
 
-  data.records.map(async (item) => {
+  data.records.map(async (item) => {    
     const f = quantUrl.prepare(item.url);
+    
     if (relativeFiles.includes(item.url) || relativeFiles.includes(f)) {
       return;
     }
+    
+    if (item.type && item.type == "redirect") {
+      // @todo: support redirects with deploy.
+      return;
+    }
+    
     try {
       // Skip unpublish process if skip unpublish regex matches.
       if (argv['skip-unpublish-regex']) {

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -178,18 +178,18 @@ command.handler = async function(argv) {
     return;
   }
 
-  data.records.map(async (item) => {    
+  data.records.map(async (item) => {
     const f = quantUrl.prepare(item.url);
-    
+
     if (relativeFiles.includes(item.url) || relativeFiles.includes(f)) {
       return;
     }
-    
-    if (item.type && item.type == "redirect") {
+
+    if (item.type && item.type == 'redirect') {
       // @todo: support redirects with deploy.
       return;
     }
-    
+
     try {
       // Skip unpublish process if skip unpublish regex matches.
       if (argv['skip-unpublish-regex']) {

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -37,6 +37,21 @@ command.handler = function(argv) { // eslint-disable-line
               console.log(chalk.yellow('\nInfo:'));
               if (data && data.total_records) {
                 console.log(`Total records: ${data.total_records}`);
+                const totals = {"content": 0, "redirects": 0}
+                
+                if (data.records) {
+                  data.records.map(async (item) => {    
+                    if (item.type && item.type == "redirect") {
+                      totals.redirects++
+                    } else {
+                      totals.content++
+                    }
+                  })
+                  console.log(`  - content: ${totals.content}`);
+                  console.log(`  - redirects: ${totals.redirects}`);
+                  
+                }
+                
               } else {
                 console.log('Use deploy to start seeding!');
               }

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -37,21 +37,19 @@ command.handler = function(argv) { // eslint-disable-line
               console.log(chalk.yellow('\nInfo:'));
               if (data && data.total_records) {
                 console.log(`Total records: ${data.total_records}`);
-                const totals = {"content": 0, "redirects": 0}
-                
+                const totals = {'content': 0, 'redirects': 0};
+
                 if (data.records) {
-                  data.records.map(async (item) => {    
-                    if (item.type && item.type == "redirect") {
-                      totals.redirects++
+                  data.records.map(async (item) => {
+                    if (item.type && item.type == 'redirect') {
+                      totals.redirects++;
                     } else {
-                      totals.content++
+                      totals.content++;
                     }
-                  })
+                  });
                   console.log(`  - content: ${totals.content}`);
                   console.log(`  - redirects: ${totals.redirects}`);
-                  
                 }
-                
               } else {
                 console.log('Use deploy to start seeding!');
               }

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -50,7 +50,7 @@ command.handler = async function(argv) {
     console.log('Something is not right.');
     yargs.exit(1);
   }
-  
+
   try {
     files = await getFiles(p);
   } catch (err) {
@@ -97,11 +97,11 @@ command.handler = async function(argv) {
     if (relativeFiles.includes(item.url) || relativeFiles.includes(f)) {
       return;
     }
-        
-    if (item.type && item.type == "redirect") {
+
+    if (item.type && item.type == 'redirect') {
       return;
     }
-        
+
     // Skip unpublish process if skip unpublish regex matches.
     if (argv['skip-unpublish-regex']) {
       const match = item.url.match(argv['skip-unpublish-regex']);

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -50,7 +50,7 @@ command.handler = async function(argv) {
     console.log('Something is not right.');
     yargs.exit(1);
   }
-
+  
   try {
     files = await getFiles(p);
   } catch (err) {
@@ -97,6 +97,11 @@ command.handler = async function(argv) {
     if (relativeFiles.includes(item.url) || relativeFiles.includes(f)) {
       return;
     }
+        
+    if (item.type && item.type == "redirect") {
+      return;
+    }
+        
     // Skip unpublish process if skip unpublish regex matches.
     if (argv['skip-unpublish-regex']) {
       const match = item.url.match(argv['skip-unpublish-regex']);

--- a/src/quant-client.js
+++ b/src/quant-client.js
@@ -121,7 +121,7 @@ const client = function(config) {
         });
 
         if (res.body.global_meta && res.body.global_meta.records) {
-          res.body.global_meta.records.map((item) => records.push({url: item.meta.url, md5: item.meta.md5}));
+          res.body.global_meta.records.map((item) => records.push({url: item.meta.url, md5: item.meta.md5, type: item.meta.type}));
         }
       };
 
@@ -142,7 +142,7 @@ const client = function(config) {
       }
 
       if (res.body.global_meta.records) {
-        res.body.global_meta.records.map((item) => records.push({url: item.meta.url, md5: item.meta.md5}));
+        res.body.global_meta.records.map((item) => records.push({url: item.meta.url, md5: item.meta.md5, type: item.meta.type}));
       }
 
       if (unfold) {


### PR DESCRIPTION
- Adds `type` to the local hash for meta objects
- Adds comparison to `type` for unpublish verification

This will skip the unpublish step for `redirects` as they're not handled by the deploy command.