### PR TITLE
Feat: Add redirect delete handling.

### DIFF
--- a/src/commands/delete.js
+++ b/src/commands/delete.js
@@ -9,6 +9,7 @@ const { text, confirm, isCancel } = require('@clack/prompts');
 const color = require('picocolors');
 const config = require('../config');
 const client = require('../quant-client');
+const deleteResponse = require('../helper/deleteResponse');
 
 const command = {
   command: 'delete <path>',

--- a/src/commands/delete.js
+++ b/src/commands/delete.js
@@ -100,19 +100,13 @@ const command = {
     } catch (err) {
       // If we have a response in the error message, try to parse it
       try {
-        const match = err.message.match(/Response: (.*)/s);
-        if (match) {
-          const responseData = JSON.parse(match[1]);
-          
-          // Check if this was actually a successful deletion
-          if (!responseData.error && responseData.meta && responseData.meta[0]) {
-            const meta = responseData.meta[0];
-            if (meta.deleted) {
-              return color.green(`Successfully removed [${args.path}]`);
-            }
-            if (meta.deleted_timestamp) {
-              return color.dim(`Path [${args.path}] was already deleted`);
-            }
+        const [ok, message] = deleteResponse(err);
+        if (ok) {
+          if (message === "success") {
+            return color.green(`Successfully removed [${args.path}]`);
+          }
+          if (message === "already deleted") {
+            return color.dim(`Path [${args.path}] was already deleted`);
           }
         }
       } catch (parseError) {

--- a/src/commands/redirect.js
+++ b/src/commands/redirect.js
@@ -4,10 +4,12 @@
  * @usage
  *   quant redirect <from> <to> [status]
  */
-const { text, select, isCancel } = require('@clack/prompts');
+const { text, select, isCancel, confirm } = require('@clack/prompts');
+const color = require('picocolors');
 const config = require('../config');
 const client = require('../quant-client');
 const isMD5Match = require('../helper/is-md5-match');
+const deleteResponse = require('../helper/deleteResponse');
 
 const command = {
   command: 'redirect <from> <to> [status]',
@@ -30,11 +32,34 @@ const command = {
         type: 'number',
         default: 302,
         choices: [301, 302, 303, 307, 308]
-      });
+      })
+      .option('delete', {
+        describe: 'Delete the redirect',
+        alias: ['d'],
+        type: 'boolean',
+        default: false
+      })
+      .option('force', {
+        describe: 'Delete without confirmation',
+        alias: ['f'],
+        type: 'boolean',
+        default: false
+      })
   },
 
   async promptArgs(providedArgs = {}) {
+    let isDelete = providedArgs.delete === true;
     let from = providedArgs.from;
+
+    if (isDelete) {
+      from = await text({
+        message: 'Enter URL to redirect from',
+        validate: value => !value ? 'From URL is required' : undefined
+      });
+      if (isCancel(from)) return null;
+      return { from, to: null, status: null, delete: true, force: providedArgs.force}
+    }
+
     if (!from) {
       from = await text({
         message: 'Enter URL to redirect from',
@@ -68,7 +93,7 @@ const command = {
       if (isCancel(status)) return null;
     }
 
-    return { from, to, status };
+    return { from, to, status, delete: false, force: false };
   },
 
   async handler(args) {
@@ -89,11 +114,36 @@ const command = {
     const status = args.status || 302;
 
     try {
-      await quant.redirect(args.from, args.to, null, status);
-      return `Created redirect from ${args.from} to ${args.to} (${status})`;
+      if (args.delete) {
+        if (!args.force) {
+          const shouldDelete = await confirm({
+            message: 'This will delete the redirect. Are you sure?',
+            initialValue: false,
+            active: 'Yes',
+            inactive: 'No'
+          });
+          if (isCancel(shouldDelete) || !shouldDelete) {
+            throw new Error('Operation cancelled');
+          }
+        }
+        await quant.delete(args.from);
+        return color.green(`Deleted redirect from ${args.from}`);
+      } else {
+        await quant.redirect(args.from, args.to, null, status);
+        return color.green(`Created redirect from ${args.from} to ${args.to} (${status})`);
+      }
     } catch (err) {
+      const [ok, message] = deleteResponse(err);
+      if (ok) {
+        if (message === "success") {
+          return color.green("Redirect was deleted");
+        }
+        if (message === "already deleted") {
+          return color.dim("Redirect was already deleted");
+        }
+      }
       if (isMD5Match(err)) {
-        return `Skipped redirect from ${args.from} to ${args.to} (already exists)`;
+        return color.dim(`Skipped redirect from ${args.from} to ${args.to} (already exists)`);
       }
       throw new Error(`Failed to create redirect: ${err.message}`);
     }

--- a/src/helper/deleteResponse.js
+++ b/src/helper/deleteResponse.js
@@ -10,7 +10,7 @@
  *   - Message, the message from the response
  */
 const deleteResponse = function(error) {
-    const reponseData = error.message.match(/Response: (.*)/s);
+    const reponseData = error.message && error.message.match(/Response: (.*)/s);
     if (reponseData) {
         const responseData = JSON.parse(reponseData[1]);
         if (responseData.meta && responseData.meta[0]) {

--- a/src/helper/deleteResponse.js
+++ b/src/helper/deleteResponse.js
@@ -1,0 +1,30 @@
+/**
+ * Handle the delete response.
+ */
+
+/**
+ * Handle the delete response.
+ * @param {*} error 
+ * @returns [boolean, string]
+ *   - Success, if the delete was successful
+ *   - Message, the message from the response
+ */
+const deleteResponse = function(error) {
+    const reponseData = error.message.match(/Response: (.*)/s);
+    if (reponseData) {
+        const responseData = JSON.parse(reponseData[1]);
+        if (responseData.meta && responseData.meta[0]) {
+            const meta = responseData.meta[0];
+            if (meta.deleted) {
+                return [true, "success"];
+            }
+            if (meta.deleted_timestamp) {
+                return [true, "already deleted"];
+            }
+        }
+    }
+
+    return [false, "unknown error"];
+}
+
+module.exports = deleteResponse;

--- a/tests/unit/commands/redirect.test.mjs
+++ b/tests/unit/commands/redirect.test.mjs
@@ -57,7 +57,7 @@ describe('Redirect Command', () => {
       };
 
       const result = await redirect.handler.call(context, args);
-      expect(result).to.equal('Created redirect from /old-path to /new-path (301)');
+      expect(result).to.include('Created redirect from /old-path to /new-path (301)');
       expect(mockClientInstance._history.post.length).to.equal(1);
     });
 
@@ -88,7 +88,7 @@ describe('Redirect Command', () => {
       };
 
       const result = await redirect.handler.call(context, args);
-      expect(result).to.equal('Skipped redirect from /old-path to /new-path (already exists)');
+      expect(result).to.include('Skipped redirect from /old-path to /new-path (already exists)');
     });
 
     it('should handle missing args', async () => {
@@ -176,7 +176,7 @@ describe('Redirect Command', () => {
       };
 
       const result = await redirect.handler.call(context, args);
-      expect(result).to.equal('Created redirect from /old-path to /new-path (302)');
+      expect(result).to.include('Created redirect from /old-path to /new-path (302)');
       expect(mockClientInstance._history.post.length).to.equal(1);
       const [call] = mockClientInstance._history.post;
       expect(call.headers['Quant-Status']).to.equal(302);


### PR DESCRIPTION
Adds two flags to the redirect command to support removing redirects.
- `--delete`: Optional boolean, confirmation will be presented to users if they delete a redirect
- `--force`: Optional boolean, skip confirmation to allow non-interactive usage


Creating redirects:
```
node cli.js redirect /old-page-cli /new-page
─────────────────────────────────────
Active configuration:
Organization: test-project
Project: static
─────────────────────────────────────
Created redirect from /old-page-cli to /new-page (302)
```
Removing redirects
```
node cli.js redirect /old-page-cli /new-page --delete --force
─────────────────────────────────────
Active configuration:
Organization: test-project
Project: static
─────────────────────────────────────
Redirect was deleted
```